### PR TITLE
Remove string cast to avoid undefined index error

### DIFF
--- a/src/Traits/HasDetail.php
+++ b/src/Traits/HasDetail.php
@@ -38,7 +38,7 @@ trait HasDetail
      */
     public function getDetail($name)
     {
-        return (string) $this->details[$name] ?? null;
+        return $this->details[$name] ?? null;
     }
 
     /**


### PR DESCRIPTION
## Description

Here the string cast takes precedence over null check, so it becomes useless and you will get an exception if the value is not set.
```php
public function getDetail($name)
{
    return (string) $this->details[$name] ?? null;
}
```
You can either remove `string` type cast which seems unnecessary in the first place, or add parentheses around the null check statement to do that before type casting.

## Motivation and context

You might wanna get some detail just in case it was available like so:
```php
$receipt->getDetail('cardNumber')
```
But now you will get an index undefined error if it's not provided by the driver.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My pull request addresses exactly one patch/feature.
