### PR TITLE
Suggest ext-soap instead of unnecessary require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,10 +85,12 @@
     ],
     "require": {
         "php": ">=7.2",
-        "ext-soap": "*",
         "illuminate/broadcasting": "^5.0|^6.0|^7.0|^8.0",
         "illuminate/support": "^5.0|^6.0|^7.0|^8.0",
         "shetabit/multipay": "^1.0"
+    },
+    "suggest": {
+        "ext-soap": "Needed to support some drivers that required SOAP"
     },
     "require-dev": {
         "orchestra/testbench": "^3.0|^4.0|^5.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Following to #85 PR, the payment package requires PHP SOAP (`ext-soap`) to be installed while it's an unnecessary change.

## Motivation and context

Some drivers don't necessarily use `ext-soap`, and not all machines have ext-soap by default. It's better to suggest `ext-soap` to developers in `commposer.json` So after installing the package, the composer will notify the user that soap may be required for some drivers.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.