### PR TITLE
Update config tag name

### DIFF
--- a/src/Provider/PaymentServiceProvider.php
+++ b/src/Provider/PaymentServiceProvider.php
@@ -26,7 +26,7 @@ class PaymentServiceProvider extends ServiceProvider
             [
                 Payment::getDefaultConfigPath() => config_path('payment.php'),
             ],
-            'config'
+            'payment-config'
         );
 
         /**


### PR DESCRIPTION
Currently, the tag name of the config file is config, which is confusing.

![image](https://user-images.githubusercontent.com/92359289/208669675-47152983-9a22-41aa-b8dd-2dbff49ba6f1.png)

 I changed it