### PR TITLE
fixed bug in loading view file `redirectForm.blade.php`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ Via Composer
 $ composer require shetabit/payment
 ```
 
+## Publish Vendor Files
+
+- **publish configuration files:**
+``` bash
+php artisan vendor:publish --tag=payment-config
+```
+
+ - **publish views for customization:**
+``` bash
+php artisan vendor:publish --tag=payment-views
+```
+
 ## Configure
 
 If you are using `Laravel 5.5` or higher then you don't need to add the provider and alias. (Skip to b)
@@ -114,8 +126,6 @@ a. In your `config/app.php` file add these two lines.
     'Payment' => Shetabit\Payment\Facade\Payment::class,
 ],
 ```
-
-b. then run `php artisan vendor:publish` to publish `config/payment.php` file in your config directory.
 
 In the config file you can set the `default driver` to use for all your payments. But you can also change the driver at runtime.
 

--- a/src/Provider/PaymentServiceProvider.php
+++ b/src/Provider/PaymentServiceProvider.php
@@ -2,9 +2,9 @@
 
 namespace Shetabit\Payment\Provider;
 
-use Shetabit\Multipay\Payment;
-use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+use Shetabit\Multipay\Payment;
 use Shetabit\Multipay\Request;
 use Shetabit\Payment\Events\InvoicePurchasedEvent;
 use Shetabit\Payment\Events\InvoiceVerifiedEvent;
@@ -18,7 +18,7 @@ class PaymentServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->loadViewsFrom(__DIR__.'/../../resources/views', 'shetabitPayment');
+        $this->loadViewsFrom(__DIR__ . '/../../resources/views', 'shetabitPayment');
 
         /**
          * Configurations that needs to be done by user.
@@ -35,9 +35,9 @@ class PaymentServiceProvider extends ServiceProvider
          */
         $this->publishes(
             [
-                __DIR__.'/../../resources/views' => resource_path('views/vendor/shetabitPayment')
+                __DIR__ . '/../../resources/views' => resource_path('views/vendor/shetabitPayment'),
             ],
-            'views'
+            'payment-views'
         );
     }
 
@@ -65,6 +65,15 @@ class PaymentServiceProvider extends ServiceProvider
 
         // use blade to render redirection form
         Payment::setRedirectionFormViewRenderer(function ($view, $action, $inputs, $method) {
+            if ($this->existCustomRedirectFormView()) {
+                return view('shetabitPayment::redirectForm')->with(
+                    [
+                        'action' => $action,
+                        'inputs' => $inputs,
+                        'method' => $method,
+                    ]
+                );
+            }
             return Blade::render(
                 str_replace('</form>', '@csrf</form>', file_get_contents($view)),
                 [
@@ -90,5 +99,15 @@ class PaymentServiceProvider extends ServiceProvider
         Payment::addVerifyListener(function ($reciept, $driver, $invoice) {
             event(new InvoiceVerifiedEvent($reciept, $driver, $invoice));
         });
+    }
+
+    /**
+     * Checks whether the user has customized the view file called `redirectForm.blade.php` or not
+     *
+     * @return bool
+     */
+    private function existCustomRedirectFormView()
+    {
+        return file_exists(resource_path('views/vendor/shetabitPayment') . '/redirectForm.blade.php');
     }
 }


### PR DESCRIPTION
After the changes applied in the 4.3.3 release (#263 ), which was aimed at solving the problem of displaying `redirectForm.blade.php` in the `Local driver`, the possibility to use customized `redirectForm.blade.php` has been lost.
In this version, I solved this problem and it is possible to use both modes.

**Note: Display priority is customized with `redirectForm.blade.php` file.**