### PR TITLE
Fixed bug in InvoicePurchasedEvent and InvoiceVerifiedEvent to use this package in Lumen framework

### DIFF
--- a/src/Events/InvoicePurchasedEvent.php
+++ b/src/Events/InvoicePurchasedEvent.php
@@ -14,7 +14,7 @@ use Shetabit\Multipay\Invoice;
 
 class InvoicePurchasedEvent
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
+    use InteractsWithSockets, SerializesModels;
 
     public $driver;
     public $invoice;

--- a/src/Events/InvoiceVerifiedEvent.php
+++ b/src/Events/InvoiceVerifiedEvent.php
@@ -15,7 +15,7 @@ use Shetabit\Multipay\Invoice;
 
 class InvoiceVerifiedEvent
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
+    use InteractsWithSockets, SerializesModels;
 
     public $receipt;
     public $driver;


### PR DESCRIPTION
Dispatchable was not found in the Lumen framework and was removed from two classes:
InvoicePurchasedEvent
InvoiceVerifiedEvent
