### PR TITLE
Merge default config with user config

### DIFF
--- a/src/Provider/PaymentServiceProvider.php
+++ b/src/Provider/PaymentServiceProvider.php
@@ -51,6 +51,9 @@ class PaymentServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        // Merge default config with user's config
+        $this->mergeConfigFrom(Payment::getDefaultConfigPath(), 'payment');
+
         Request::overwrite('input', function ($key) {
             return \request($key);
         });


### PR DESCRIPTION
بر اساس مستندات لاراول (https://laravel.com/docs/10.x/packages#default-package-configuration) برای اینکه کاربر این امکان رو داشته باشه که فقط مقادیری از فایل کانفیگ رو که نیاز داره بتونه overwrite کنه این متد اضافه شد
مثلا با این تغییر کاربر امکان تعریف کانفیگ فقط به صورت زیر رو داره
```
<?php

return [
    'default' => 'zarinpal',
];
```