### PR TITLE
Add imports checker to github flows

### DIFF
--- a/src/Events/InvoicePurchasedEvent.php
+++ b/src/Events/InvoicePurchasedEvent.php
@@ -2,13 +2,9 @@
 
 namespace Shetabit\Payment\Events;
 
-use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Broadcasting\PresenceChannel;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Shetabit\Multipay\Contracts\DriverInterface;
 use Shetabit\Multipay\Invoice;
 

--- a/src/Events/InvoiceVerifiedEvent.php
+++ b/src/Events/InvoiceVerifiedEvent.php
@@ -2,13 +2,9 @@
 
 namespace Shetabit\Payment\Events;
 
-use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Broadcasting\PresenceChannel;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Shetabit\Multipay\Contracts\DriverInterface;
 use Shetabit\Multipay\Contracts\ReceiptInterface;
 use Shetabit\Multipay\Invoice;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,7 @@
 namespace Shetabit\Payment\Tests;
 
 use Orchestra\Testbench\TestCase as BaseTestCase;
-use Shetabit\Payment\Tests\Mocks\Drivers\BarDriver;
+use Shetabit\Multipay\Tests\Drivers\BarDriver;
 
 class TestCase extends BaseTestCase
 {


### PR DESCRIPTION
Adds import checker to GitHub workflows to reveal "extra" or "wrong" use statements.
 
- This PR also includes a commit to remove an extra import so that the checks pass.
- You will also have a badge in the readme file indicating that all the imports (use statements) are correct.
