### PR TITLE
remove $ from package installation command in readme

### DIFF
--- a/README-FA.md
+++ b/README-FA.md
@@ -101,7 +101,7 @@
 </div>
 
 ``` bash
-$ composer require shetabit/payment
+composer require shetabit/payment
 ```
 
 <div dir="rtl">

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -106,7 +106,7 @@ For PHP integration you can use [shetabit/multipay](https://github.com/shetabit/
 通过 Composer
 
 ``` bash
-$ composer require shetabit/payment
+composer require shetabit/payment
 ```
 
 ## 配置

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ For PHP integration you can use [shetabit/multipay](https://github.com/shetabit/
 Via Composer
 
 ``` bash
-$ composer require shetabit/payment
+composer require shetabit/payment
 ```
 
 ## Publish Vendor Files


### PR DESCRIPTION
سلام
موقع کپی کامند نصب پکیج علامت $ اضافه است و کپی میشه که پاک شد.