### PR TITLE
[FIX] Laravel 12.x Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
     ],
     "require": {
         "php": ">=8.0",
-        "illuminate/broadcasting": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/broadcasting": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
         "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
         "shetabit/multipay": "^1.0|^2.0"
     },
@@ -93,7 +93,7 @@
         "ext-soap": "Needed to support some drivers that required SOAP"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.0|^4.0|^5.0|^6.0|^7.0|^8.0|^9.0",
+        "orchestra/testbench": "^3.0|^4.0|^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",
         "phpunit/phpunit": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "squizlabs/php_codesniffer": "^3.5"
     },


### PR DESCRIPTION
This fix addresses the recent release [v6.1.0](https://github.com/shetabit/payment/releases/tag/v6.1.0), enabling Laravel 12 support for the `shetabit/payment` package.


related: https://github.com/shetabit/payment/pull/338 https://github.com/shetabit/payment/issues/337